### PR TITLE
Add a basic search page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ docs:
     ++extra ./node_modules/pyret-codemirror-mode/mode/pyret.js \
     ++style ./node_modules/pyret-codemirror-mode/css/pyret.css \
     ++extra src/hilite.js \
+    ++extra src/search.js \
     \
     ++style src/styles.css \
     --prefix src/myprefix.html \
@@ -22,6 +23,7 @@ docs:
     --htmls-search src/index.scrbl
 	mkdir -p build/docs/search
 	cp src/search.html build/docs/search/index.html
+	patch build/docs/scribble-common.js src/scribble-common.patch
 
 release-docs: docs
 	scp -r build/docs/* $(DOCS_TARGET)/$(VERSION)/

--- a/README.md
+++ b/README.md
@@ -10,21 +10,18 @@ Program in Pyret at https://code.pyret.org.
 
 ### Installing
 
-Make sure you have [Scribble](https://docs.racket-lang.org/scribble/) runnable.
-The easiest way to install Scribble is to
-[install Racket](https://racket-lang.org/download/) which will install Scribble
-as well.
+Make sure you [install Racket](https://racket-lang.org/download/).
 
-If you are using a Mac, `scribble` will not be runnable automatically.
-If you are using Racket 6.5 and install the program at
-`/Applications/Racket\ v6.5/`, for example, you need to put
+If you are using a Mac, `racket` will not be runnable automatically.
+To make it runnable, say that you are using Racket 6.5 and install the program at
+`/Applications/Racket\ v6.5/`, you need to put
 
     export PATH=$PATH:/Applications/Racket\ v6.5/bin/
 
 to `.bashrc` (if you use Bash) and then restart the shell to make it take
 an effect.
 
-Also make sure you have `node` (and `npm`).
+Also make sure you have `node` and `npm`.
 
 When you have everything mentioned above, run `make install` to download
 additional files needed for compilation.

--- a/scribble-api.rkt
+++ b/scribble-api.rkt
@@ -971,7 +971,7 @@
 
       (define body
         (list (make-element "content-body"
-                            (flatten (map get-link-and-anchor index-groups)))))
+                            (apply append (map get-link-and-anchor index-groups)))))
       (if manual-newlines?
         (rows wrapped-alpha-row '(nbsp) body)
         (apply rows wrapped-alpha-row '(nbsp) (map list body)))))

--- a/scribble-api.rkt
+++ b/scribble-api.rkt
@@ -913,8 +913,8 @@
                         [name (first tag-path)]
                         [path (rest tag-path)]
                         [link-content
-                         (if (empty? path) (list name)
-                             (list name " (from " (add-between path " » ") ")"))]
+                         (if (empty? path) (list (make-element "single-name" name))
+                             (list name (make-element "origin" (list " (from " (add-between path " » ") ")"))))]
                         [e (make-link-element "indexlink" `(,link-content ,br) (car item))])
                    (cond [(hash-ref alpha-starts item #f)
                           => (lambda (let)
@@ -926,24 +926,26 @@
                          [else e]))]
                 [else ;; multiple items with a common term
                  (define group-name (first (third (first group))))
-                 (cons (make-element #f (list group-name br))
-                       (map (lambda (item)
-                              (let* ([tag-path (caddr item)]
-                                     [name (first tag-path)]
-                                     [path (rest tag-path)]
-                                     [link-content (add-between path " » ")]
-                                     [e (list (hspace 4)
-                                             "from "
-                                             (make-link-element "indexlink" `(,link-content ,br) (car item)))])
-                                (cond [(hash-ref alpha-starts item #f)
-                                       => (lambda (let)
-                                            (make-element
-                                             (make-style #f (list
-                                                             (make-url-anchor
-                                                              (format "alpha:~a" (char-upcase let)))))
-                                             (list e)))]
-                                      [else e])))
-                          group))]))
+                 (make-element
+                  "multi-link"
+                  (cons (make-element #f (list group-name br))
+                        (map (lambda (item)
+                               (let* ([tag-path (caddr item)]
+                                      [name (first tag-path)]
+                                      [path (rest tag-path)]
+                                      [link-content (add-between path " » ")]
+                                      [e (list (hspace 4)
+                                               "from "
+                                               (make-link-element "indexlink" `(,link-content ,br) (car item)))])
+                                 (cond [(hash-ref alpha-starts item #f)
+                                        => (lambda (let)
+                                             (make-element
+                                              (make-style #f (list
+                                                              (make-url-anchor
+                                                               (format "alpha:~a" (char-upcase let)))))
+                                              (list e)))]
+                                       [else e])))
+                             group)))]))
                index-groups))
       (if manual-newlines?
         (rows alpha-row '(nbsp) body)

--- a/scribble-api.rkt
+++ b/scribble-api.rkt
@@ -25,6 +25,7 @@
          racket/string
          racket/runtime-path
          scheme/class
+         racket/match
          "scribble-helpers.rkt"
          "ragged.rkt"
          "ebnf.rkt"
@@ -903,51 +904,75 @@
                                  " "
                                  (loop (cdr i) (cdr alpha)))]
                          [else (loop (cdr i) alpha)]))])))
+      (define wrapped-alpha-row (make-element "alpha-row" alpha-row))
       (define br (if manual-newlines? (make-element 'newline '("\n")) ""))
+
+      ;; Here, we want to create a list of links. However, since for each datum,
+      ;; there might be an attached anchor too, we will need to flatten the
+      ;; list of results.
+
+      ;; A Link is a node which has either one or two parts (not counting link break).
+      ;; The first one is link-name, and the second one (which might not exist) is origin.
+
+      ;; NOTE: make-element will not create a new node if the style if #f
+      ;; so we need to specify it if we want the node to be created
+
+      ;; get-link : Group -> Link
+      (define (get-link group)
+        (match group
+          [(list item)
+           (let* ([tag-path (caddr item)]
+                  [name (first tag-path)]
+                  [path (rest tag-path)]
+                  [name-element (make-element "link-name" name)]
+                  [link-content
+                   (match path
+                     ['() (list name-element)]
+                     [_ (list name-element
+                              (make-element "origin"
+                                            `(" (from "
+                                              ,(add-between path " » ") ")")))])])
+             (make-link-element "indexlink"
+                                (append link-content (list br))
+                                (car item)))]
+          [_
+           (define group-name (first (third (first group))))
+           (define (get-origin item)
+             (let* ([tag-path (caddr item)]
+                    [name (first tag-path)]
+                    [path (rest tag-path)]
+                    [link-content (add-between path " » ")])
+               (list (hspace 4)
+                     "from "
+                     (make-link-element "indexlink"
+                                        `(,link-content ,br)
+                                        (car item)))))
+           (make-element
+            "indexlinks"
+            (list (make-element "link-name" group-name)
+                  br
+                  (make-element "origin" (map get-origin group))))]))
+
+      ;; get-link-and-anchor : Group -> ([Anchor, Link] | [Link])
+      (define (get-link-and-anchor group)
+        (define link (get-link group))
+        (define first-item
+          (match group
+            [(list item) item]
+            [(list item _ ...) item]))
+        (cond
+          [(hash-ref alpha-starts first-item #f)
+           => (lambda (letter)
+                (define anchor-style
+                  (list (make-url-anchor (format "alpha:~a" (char-upcase letter)))))
+                (define anchor (make-element (make-style "post-anchor" anchor-style) '()))
+                (list anchor link))]
+          [else (list link)]))
+
       (define body
-        (map (lambda(group)
-               (cond
-                [(empty? (rest group)) ;; is actually a single item
-                 (let* ([item (first group)]
-                        [tag-path (caddr item)]
-                        [name (first tag-path)]
-                        [path (rest tag-path)]
-                        [link-content
-                         (if (empty? path) (list (make-element "single-name" name))
-                             (list name (make-element "origin" (list " (from " (add-between path " » ") ")"))))]
-                        [e (make-link-element "indexlink" `(,link-content ,br) (car item))])
-                   (cond [(hash-ref alpha-starts item #f)
-                          => (lambda (let)
-                               (make-element
-                                (make-style #f (list
-                                                (make-url-anchor
-                                                 (format "alpha:~a" (char-upcase let)))))
-                                (list e)))]
-                         [else e]))]
-                [else ;; multiple items with a common term
-                 (define group-name (first (third (first group))))
-                 (make-element
-                  "multi-link"
-                  (cons (make-element #f (list group-name br))
-                        (map (lambda (item)
-                               (let* ([tag-path (caddr item)]
-                                      [name (first tag-path)]
-                                      [path (rest tag-path)]
-                                      [link-content (add-between path " » ")]
-                                      [e (list (hspace 4)
-                                               "from "
-                                               (make-link-element "indexlink" `(,link-content ,br) (car item)))])
-                                 (cond [(hash-ref alpha-starts item #f)
-                                        => (lambda (let)
-                                             (make-element
-                                              (make-style #f (list
-                                                              (make-url-anchor
-                                                               (format "alpha:~a" (char-upcase let)))))
-                                              (list e)))]
-                                       [else e])))
-                             group)))]))
-               index-groups))
+        (list (make-element "content-body"
+                            (flatten (map get-link-and-anchor index-groups)))))
       (if manual-newlines?
-        (rows alpha-row '(nbsp) body)
-        (apply rows alpha-row '(nbsp) (map list body)))))
+        (rows wrapped-alpha-row '(nbsp) body)
+        (apply rows wrapped-alpha-row '(nbsp) (map list body)))))
   (make-delayed-block contents))

--- a/src/myprefix.html
+++ b/src/myprefix.html
@@ -4,3 +4,4 @@
 <script src="runmode.js"></script>
 <script src="pyret.js"></script>
 <script src="hilite.js"></script>
+<script src="search.js"></script>

--- a/src/scribble-common.patch
+++ b/src/scribble-common.patch
@@ -1,0 +1,3 @@
+162,163d161
+<     var links = document.getElementsByTagName("a");
+<     for (var i=0; i<links.length; i++) MergePageArgsIntoLink(links[i]);

--- a/src/search.html
+++ b/src/search.html
@@ -1,18 +1,7 @@
 <html>
 <body>
 <script type="text/javascript">
-// adapted from https://stackoverflow.com/questions/11823784/redirection-to-a-specific-web-page-based-on-url-parameter-using-javascript
-function getQueryStringMap(){
-    var assoc = {};
-    window.location.search.substring(1).split('&').forEach(function(v) {
-        var pair = v.split('=');
-        assoc[pair[0]] = pair[1];
-    });
-    return assoc;
-}
-
-var qs = getQueryStringMap();
-window.location.href = 'https://www.google.com/search?q=site%3Apyret.org%2Fdocs+' + qs.q;
+window.location.href = '../Glossary.html' + window.location.search;
 </script>
 </body>
 </html>

--- a/src/search.js
+++ b/src/search.js
@@ -10,21 +10,49 @@ function getQueryStringMap(){
 $(function(){
     var header = $('a[name="(part._.Glossary)"]');
     if (header.length == 0) return;
+
     var qs = getQueryStringMap();
-    if (!qs.q) return;
-    $('table > tbody > tr > td > p').children().each(function() {
-        var item = $(this);
-        var link = item;
-        if (link.attr('name')) return; // Links from TOC
-        if (!link.hasClass('indexlink') && !link.hasClass('multi-link')) {
-            // Links that are right after links from TOC
-            // They are malformed somehow. Here's a hack to make it work.
-            link = link.children().first();
-        }
-        if (link.children().first().text().toLowerCase().indexOf(qs.q.toLowerCase()) != -1) {
-            item.removeClass('hidelink');
-        } else {
-            item.addClass('hidelink');
-        }
-    });
+
+    var content = $('.content-body');
+    var alphaRow = $('.alpha-row');
+    var inputBox = $('<input/>', {
+        'class': 'searchbox large',
+        placeholder: '...search manual...',
+        size: "64",
+    })
+        .val(qs.q ? qs.q : '')
+        .on('input', function() {
+            var query = inputBox.val();
+            if (query != '') {
+                alphaRow.addClass('hide');
+            } else {
+                alphaRow.removeClass('hide');
+            }
+            content.children().each(function() {
+                // An item could be either
+                // 1. An anchor (need to skip)
+                // 2. A post-anchor (empty span, need to skip)
+                // 3. indexlink (need to process)
+                // 4. indexlinks (need to process)
+                var item = $(this);
+                var link = item;
+                // skip for anchor and post anchor
+                if (link.attr('name') || link.hasClass('post-anchor')) return;
+                var linkName = link.children().first().text();
+                if (linkName.toLowerCase().indexOf(query.toLowerCase()) != -1) {
+                    item.removeClass('hide');
+                } else {
+                    item.addClass('hide');
+                }
+            });
+        });
+
+    var inputGroup = $('<tr/>').append(
+        $('<td/>')
+            .append(inputBox)
+            .append($('</br>')));
+    // a very ugly way to find the appropriate place to insert, but I don't
+    // know a better way
+    alphaRow.parent().parent().parent().before(inputGroup);
+    inputBox.trigger('input');
 });

--- a/src/search.js
+++ b/src/search.js
@@ -1,0 +1,30 @@
+function getQueryStringMap(){
+    var assoc = {};
+    window.location.search.substring(1).split('&').forEach(function(v) {
+        var pair = v.split('=');
+        assoc[pair[0]] = pair[1];
+    });
+    return assoc;
+}
+
+$(function(){
+    var header = $('a[name="(part._.Glossary)"]');
+    if (header.length == 0) return;
+    var qs = getQueryStringMap();
+    if (!qs.q) return;
+    $('table > tbody > tr > td > p').children().each(function() {
+        var item = $(this);
+        var link = item;
+        if (link.attr('name')) return; // Links from TOC
+        if (!link.hasClass('indexlink') && !link.hasClass('multi-link')) {
+            // Links that are right after links from TOC
+            // They are malformed somehow. Here's a hack to make it work.
+            link = link.children().first();
+        }
+        if (link.children().first().text().toLowerCase().indexOf(qs.q.toLowerCase()) != -1) {
+            item.removeClass('hidelink');
+        } else {
+            item.addClass('hidelink');
+        }
+    });
+});

--- a/src/search.js
+++ b/src/search.js
@@ -18,7 +18,6 @@ $(function(){
     var inputBox = $('<input/>', {
         'class': 'searchbox large',
         placeholder: '...search manual...',
-        size: "64",
     })
         .val(qs.q ? qs.q : '')
         .on('input', function() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -75,3 +75,7 @@ pre.pyret-block {
    content: attr(data-prod);
    color: transparent;
 }
+
+.hidelink {
+    display: none;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -76,6 +76,10 @@ pre.pyret-block {
    color: transparent;
 }
 
-.hidelink {
+.hide {
     display: none;
+}
+
+.searchbox.large {
+    width: 24rem;
 }


### PR DESCRIPTION
This commit hacks the glossary page to be a search result page in the same time.
Note that Scribble has a functionality to propagate query strings via links,
but this would interact badly with this new feature, so we need to explicitly
patch it.