### PR TITLE
Correct overlay-xy examples

### DIFF
--- a/src/trove/image.js.rkt
+++ b/src/trove/image.js.rkt
@@ -721,14 +721,17 @@
     by @pyret{dx} pixels, and then down by @pyret{dy} pixels.
   }
   @repl-examples[
-    `(@{overlay-xy(0, 0,
-          square(30, "solid", "bisque"), square(50, "solid", "dark-green"))}
+    `(@{overlay-xy(square(30, "solid", "bisque"),
+          0, 0,
+          square(50, "solid", "dark-green"))}
       ,(overlay/xy (square 30 "solid" "bisque") 0 0 (square 50 "solid" "darkgreen")))
-    `(@{overlay-xy(30, 20, # Move green square right 30 and down 20
-          square(30, "solid", "bisque"), square(50, "solid", "dark-green"))}
+    `(@{overlay-xy(square(30, "solid", "bisque"),
+          30, 20, # Move green square right 30 and down 20
+          square(50, "solid", "dark-green"))}
       ,(overlay/xy (square 30 "solid" "bisque") 30 20 (square 50 "solid" "darkgreen")))
-    `(@{overlay-xy(-10, -20, # Move green square left 10 and up 20
-          square(30, "solid", "bisque"), square(50, "solid", "dark-green"))}
+    `(@{overlay-xy(square(30, "solid", "bisque"),
+          -10, -20, # Move green square left 10 and up 20
+          square(50, "solid", "dark-green"))}
       ,(overlay/xy (square 30 "solid" "bisque") -10 -20 (square 50 "solid" "darkgreen")))
   ]
   @function[


### PR DESCRIPTION
A student caught this in class today--the `overlay-xy` arguments are in the wrong order in the examples.