### PR TITLE
fix copy/paste bug in from-list.histogram

### DIFF
--- a/src/trove/chart.js.rkt
+++ b/src/trove/chart.js.rkt
@@ -571,7 +571,7 @@ a-series = from-list.exploding-pie-chart(
     See more details at @(in-link "histogram-series").
 
     @examples{
-a-series = from-list.labeled-histogram(range(1, 100).map(lam(_): num-random(1000) end))
+a-series = from-list.histogram(range(1, 100).map(lam(_): num-random(1000) end))
     }
   }
 


### PR DESCRIPTION
Small nuisance I noticed this afternoon, in which the example for `from-list.histogram` actually used `from-list.labeled-histogram`