### PR TITLE
add patch from @blerner to provide better errors

### DIFF
--- a/scribble-api.rkt
+++ b/scribble-api.rkt
@@ -211,8 +211,9 @@
   (if (or (empty? indefns) (not indefns))
       #f
       (let ([d (findf (lambda (d)
-                        (and (list? (spec-fields d))
-                             (equal? for-val (field-val (assoc by-field (spec-fields d)))))) indefns)])
+                        (with-handlers [(exn:fail:contract? (lambda(e) #f))]
+                          (and (list? (spec-fields d))
+                               (equal? for-val (field-val (assoc by-field (spec-fields d))))))) indefns)])
         d)))
 
 
@@ -222,8 +223,9 @@
   (if (or (empty? indefns) (not indefns))
       #f
       (let ([d (findf (lambda (d)
-                        (and (list? (spec-fields d))
-                             (equal? for-val (field-val (assoc by-field (spec-fields d)))))) indefns)])
+                        (with-handlers [(exn:fail:contract? (lambda(e) #f))]
+                          (and (list? (spec-fields d))
+                               (equal? for-val (field-val (assoc by-field (spec-fields d))))))) indefns)])
         (unless d
           (warning 'find-defn (format "No definition for field '~a = \"~a\" in module ~s" by-field for-val indefns)))
         d)))


### PR DESCRIPTION
Trying this a second time...
------
When a `ChartWindow` declares methods which it doesn't actually contain, the resulting error is not helpful:
```
second: contract violation
  expected: list?
  given: #f
  context...:
   /Users/schanzer/Documents/Bootstrap/Development/pyret-docs/scribble-api.rkt:213:22
   /Applications/Racketv8.0/collects/racket/private/list.rkt:115:2: findf
   /Users/schanzer/Documents/Bootstrap/Development/pyret-docs/scribble-api.rkt:210:0: find-defn/nowarn
   /Users/schanzer/Documents/Bootstrap/Development/pyret-docs/scribble-api.rkt:489:1: method-doc
   body of "/Users/schanzer/Documents/Bootstrap/Development/pyret-docs/src/trove/chart.js.rkt"
```

This patch, from @blerner , gives the following error instead:
```
WARNING in method-doc: No definition for method horizontal for data ChartWindow and variant box-plot-chart-window in module "chart"
Could not find spec for horizontal
  context...:
   body of "/Users/schanzer/Documents/Bootstrap/Development/pyret-docs/src/trove/chart.js.rkt"
   .../private/map.rkt:40:19: loop
   /Applications/Racketv8.0/collects/racket/cmdline.rkt:191:51
   body of "/Users/schanzer/Documents/Bootstrap/Development/pyret-docs/run.rkt"
make: *** [docs] Error 1
```