### PR TITLE
note distinction between method bindings and method values

### DIFF
--- a/src/lang/forms.scrbl
+++ b/src/lang/forms.scrbl
@@ -2002,6 +2002,24 @@ of three things:
         the-m-method-closed-over-o(5) is 27
       end
     }
+
+    Note that a method binding is not a itself a method value.
+    Creating new objects from method bindings will not behave the same
+    as using method values directly.
+
+    For example:
+
+    @pyret-block{
+      code = method(self, x): self.y + x end
+      p = { y: 10, m: code }
+      q = p.{ y: 15 }
+      r = { y: 20, m: p.m } # m given method binding, not a method
+      check:
+        p.m(5) is 15
+        q.m(5) is 20 # self.y dynamically resolved when code runs
+        r.m(5) is 15 # but this is not 25, because r.m is p.m
+      end
+    }
   }
 ]
 


### PR DESCRIPTION
note distinction between method bindings and method values in docs for dot expressions.

offshoot of https://github.com/brownplt/pyret-lang/issues/1661

----

(Note that there is a *chance* that the language designers did *not* intend for method bindings to be distinct from method values, in which case this is an implementation bug. I.e., there is a sensible semantics that says that method bindings behave like functions, except that they are still method values and can be *rebound* when they are put into *different objects*.)
