### PR TITLE
search: handle spaces

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -1,17 +1,8 @@
-function getQueryStringMap(){
-    var assoc = {};
-    window.location.search.substring(1).split('&').forEach(function(v) {
-        var pair = v.split('=');
-        assoc[pair[0]] = pair[1];
-    });
-    return assoc;
-}
-
 $(function(){
     var header = $('a[name="(part._.Glossary)"]');
     if (header.length == 0) return;
 
-    var qs = getQueryStringMap();
+    const qs = new URLSearchParams(window.location.search);
 
     var content = $('.content-body');
     var alphaRow = $('.alpha-row');
@@ -19,7 +10,7 @@ $(function(){
         'class': 'searchbox large',
         placeholder: '...search manual...',
     })
-        .val(qs.q ? qs.q : '')
+        .val(qs.get('q') || '')
         .on('input', function() {
             var query = inputBox.val();
             if (query != '') {


### PR DESCRIPTION
Prior this PR, searching for "function plot" in the search bar resulted in "function%20plot" in the glossary page's search box. This PR fixes the issue by using `URLSearchParams`, which automatically calls `decodeURIComponent` for us. We also no longer need to parse the query string to a map ourselves.

`URLSearchParams` is supported in most major browsers since 2016/2017.

Fixes #75